### PR TITLE
Adds a Dockerfile that we can use to build our own image of BackstopJS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM backstopjs/backstopjs
+
+# Creates a Docker group and Jenkins user so that files created within the container are modifiable by the host.
+
+RUN addgroup -g 999 docker
+RUN adduser -Ds /bin/bash -u 106 -G docker jenkins
+USER jenkins

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ With the basic setup as supplied, this will run an initial test on your localhos
 `npm run approve -- --configPath=config.js`
 
 Now you can happily change your local apps and run tests (with `npm run test`) to make sure you've not broken things!  Everytime you do a good change, simply `npm run approve` to update your reference screenshots.
+
+## Updating the docker image
+
+Update `VERSION` in the script whenever you make changes to the image configuration. Until BackstopJS has versioned Docker images, re-building our copy will pull in the latest version of BackstopJS, so be aware of that.
+
+Then run `./scripts/build-and-push-docker-image.sh` and update the Docker image version pulled by the visual-regression Jenkins job.

--- a/scripts/build-and-push-docker-image.sh
+++ b/scripts/build-and-push-docker-image.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+VERSION=1.0.0
+
+docker build -t digitalmarketplace/backstopjs:${VERSION} .
+docker push digitalmarketplace/backstopjs:${VERSION}


### PR DESCRIPTION
We do this to set up a docker group and jenkins user inside the
container that map to those on the host. This means files created by the
container (e.g. backstop_data/bitmaps_test) will be editable by the
Jenkins job we are running, allowing us to delete them as appropriate to
keep disk usage low.