### PR TITLE
Add Category and Sourcing admin pages and remove user list page test

### DIFF
--- a/backstop_data/engine_scripts/casper/user.js
+++ b/backstop_data/engine_scripts/casper/user.js
@@ -7,13 +7,13 @@ module.exports = function (casper, scenario) {
   } else if (scenario.user === 'buyer') {
     var email = system.env.DM_PRODUCTION_BUYER_USER_EMAIL;
     var password = system.env.DM_PRODUCTION_BUYER_USER_PASSWORD;
-  } else if (scenario.user === 'admin') {
+  } else if (scenario.user === 'admin-support') {
     var email = system.env.DM_PRODUCTION_ADMIN_USER_EMAIL;
     var password = system.env.DM_PRODUCTION_ADMIN_USER_PASSWORD;
-  } else if (scenario.user === 'category') {
+  } else if (scenario.user === 'admin-category') {
     var email = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL;
     var password = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD;
-  } else if (scenario.user === 'sourcing') {
+  } else if (scenario.user === 'admin-sourcing') {
     var email = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL;
     var password = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD;
   } else {

--- a/backstop_data/engine_scripts/casper/user.js
+++ b/backstop_data/engine_scripts/casper/user.js
@@ -10,6 +10,12 @@ module.exports = function (casper, scenario) {
   } else if (scenario.user === 'admin') {
     var email = system.env.DM_PRODUCTION_ADMIN_USER_EMAIL;
     var password = system.env.DM_PRODUCTION_ADMIN_USER_PASSWORD;
+  } else if (scenario.user === 'category') {
+    var email = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL;
+    var password = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD;
+  } else if (scenario.user === 'sourcing') {
+    var email = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL;
+    var password = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD;
   } else {
     casper.echo('No user required for this scenario.', 'DEBUG');
   }

--- a/config.js
+++ b/config.js
@@ -137,29 +137,29 @@ module.exports = {
     {
       "label": environment + ": Admin - Account - dashboard",
       "url": domain + "/admin",
-      "user": "admin",
+      "user": "admin-support",
     },
     {
       "label": environment + ": Admin - Account - Add buyer domain",
       "url": domain + "/admin/buyers/add-buyer-domains",
-      "user": "admin",
+      "user": "admin-support",
     },
     {
       "label": environment + ": Admin - Account - Suppliers starting with 'a'",
       "url": domain + "/admin/suppliers?supplier_name_prefix=a",
-      "user": "admin",
+      "user": "admin-support",
     },
 
     {
       "label": environment + ": Category - Account - dashboard",
       "url": domain + "/admin",
-      "user": "category",
+      "user": "admin-category",
     },
 
     {
       "label": environment + ": Sourcing - Account - On-Hold DOS2 agreements",
       "url": domain + "/admin/agreements/digital-outcomes-and-specialists-2?status=on-hold",
-      "user": "sourcing",
+      "user": "admin-sourcing",
     }
   ],
   "paths": {

--- a/config.js
+++ b/config.js
@@ -149,10 +149,17 @@ module.exports = {
       "url": domain + "/admin/suppliers?supplier_name_prefix=a",
       "user": "admin",
     },
+
     {
-      "label": environment + ": Admin - Account - Download user lists",
-      "url": domain + "/admin/users/download",
-      "user": "admin",
+      "label": environment + ": Category - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "category",
+    },
+
+    {
+      "label": environment + ": Sourcing - Account - On-Hold DOS2 agreements",
+      "url": domain + "/admin/agreements/digital-outcomes-and-specialists-2?status=on-hold",
+      "user": "sourcing",
     }
   ],
   "paths": {


### PR DESCRIPTION
The user list page is now restricted to the new "framework manager" role
which we don't have a user account set up for yet.  And the page will be
going away altogether in the next week or so, so not worth patching up
that test right now.

Category and Sourcing accounts added, with one page tested for each new
type of user.

It's not clear to me from the README what I'll need to do if/when this is approved and merged... what is the Docker stuff for? Do I need to build and push a new Docker image before the changes will be picked up? Or will I be able to just run the job in Jenkins and it will pull the new version in?