### PR TITLE
Re-order test scenarios to provoke new login

### DIFF
--- a/config.js
+++ b/config.js
@@ -79,6 +79,11 @@ module.exports = {
       "url": domain + "/user/reset-password/1",
     },
 
+    {
+      "label": environment + ": Category - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-category",
+    },
 
     {
       "label": environment + ": Buyer - Account - Dashboard",
@@ -104,6 +109,11 @@ module.exports = {
       "user": "buyer"
     },
 
+    {
+      "label": environment + ": Sourcing - Account - On-Hold DOS2 agreements",
+      "url": domain + "/admin/agreements/digital-outcomes-and-specialists-2?status=on-hold",
+      "user": "admin-sourcing",
+    },
 
     {
       "label": environment + ": Supplier - Sign up for framework alerts",
@@ -148,18 +158,6 @@ module.exports = {
       "label": environment + ": Admin - Account - Suppliers starting with 'a'",
       "url": domain + "/admin/suppliers?supplier_name_prefix=a",
       "user": "admin-support",
-    },
-
-    {
-      "label": environment + ": Category - Account - dashboard",
-      "url": domain + "/admin",
-      "user": "admin-category",
-    },
-
-    {
-      "label": environment + ": Sourcing - Account - On-Hold DOS2 agreements",
-      "url": domain + "/admin/agreements/digital-outcomes-and-specialists-2?status=on-hold",
-      "user": "admin-sourcing",
     }
   ],
   "paths": {


### PR DESCRIPTION
**THIS IS A TERRIBLE HACK THAT MUST BE FIXED PROPERLY SOON**

The tests are deciding whether to re-log in based on if the bot is redirected to the login page when it tries to access the URL.  This meant that for different admin user roles the new role was not being logged in, and all admin pages screenshotted as admin (support) role.

By rearranging so that admin roles are interleaved with other roles we should be able to provoke a new login with the correct user for this set of tests.

This is by no means a permanent solution, but a quick hack for Friday to unblock our release pipeline.  Someone *will* make a better fix soon.