### PR TITLE
Update url for 'What buyers will see' page

### DIFF
--- a/config.js
+++ b/config.js
@@ -140,7 +140,7 @@ module.exports = {
     },
     {
       "label": environment + ": Supplier - Account - Edit details",
-      "url": domain + "/suppliers/details/edit",
+      "url": domain + "/suppliers/what-buyers-will-see/edit",
       "user": "supplier",
     },
 


### PR DESCRIPTION
Following route change for this page in supplier-frontend:
https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/799