### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM backstopjs/backstopjs
+FROM backstopjs/backstopjs:v3.0.38
 
 # Creates a Docker group and Jenkins user so that files created within the container are modifiable by the host.
 


### PR DESCRIPTION
`backstopjs` has changed their base image from alpine to Debian, which broke our Dockerfile as it was written for busybox versions of `adduser` and `addgroup`.

We also have to delete the user `saned` as they have uid 106 in the base image, but we want 106 so as to align with our Jenkins box.