### PR TITLE
Update jenkins UID and bump verison to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Digital Marketplace Visual Regression changelog
+
+Records breaking changes from major version bumps
+
+## 2.0.0
+
+PR: [#15](https://github.com/alphagov/digitalmarketplace-visual-regression/pull/15)
+
+The user id of the Jenkins user created for the container has changed from 106 to 1001. This is due to the new Jenkins
+box having a different UID for it's jenkins user than the original one.
+
+These ID's need to match, as the volume we map to the container has the same owner inside and outside the running
+container. If the container's jenkins user's UID doesn't match the volume owner's, there are file permission errors.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM backstopjs/backstopjs:v3.0.38
 # Creates a Docker group and Jenkins user so that files created within the container are modifiable by the host.
 
 RUN addgroup -g 999 docker
-RUN adduser -Ds /bin/bash -u 106 -G docker jenkins
+RUN adduser -Ds /bin/bash -u 1001 -G docker jenkins
 USER jenkins

--- a/scripts/build-and-push-docker-image.sh
+++ b/scripts/build-and-push-docker-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=1.0.0
+VERSION=2.0.0
 
 docker build -t digitalmarketplace/backstopjs:${VERSION} .
 docker push digitalmarketplace/backstopjs:${VERSION}


### PR DESCRIPTION
The visual regression tests Dockerfile creates a user called 'jenkins' and specifies it's UID. This UID has to match with the owner of the directory that gets mounted as a volume into the container. Currently the UID in the Dockerfile is hardcoded to match the UID of the jenkins user on the Jenkins box. This is bad. If the jenkins user changes UID (maybe the box gets rebuilt again) the job breaks.