### PR TITLE
Update DOS2 urls for DOS3

### DIFF
--- a/config.js
+++ b/config.js
@@ -55,11 +55,11 @@ module.exports = {
 
     {
       "label": environment + ": DOS - Find a specialist",
-      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists"
+      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-3/requirements/digital-specialists"
     },
     {
       "label": environment + ": DOS - Find a user research studio",
-      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/user-research-studios"
+      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-3/requirements/user-research-studios"
     },
 
 
@@ -102,12 +102,12 @@ module.exports = {
     },
     {
       "label": environment + ": Buyer - Account - Create requirement form",
-      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/create",
+      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-3/requirements/digital-specialists/create",
       "user": "buyer",
     },
     {
       "label": environment + ": Buyer - Account - Create requirement form - Validation",
-      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/create",
+      "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-3/requirements/digital-specialists/create",
       "user": "buyer",
       "submitForm": true
     },
@@ -167,7 +167,7 @@ module.exports = {
 
     {
       "label": environment + ": Admin (Sourcing) - Account - On-Hold DOS2 agreements",
-      "url": domain + "/admin/agreements/digital-outcomes-and-specialists-2?status=on-hold",
+      "url": domain + "/admin/agreements/digital-outcomes-and-specialists-3?status=on-hold",
       "user": "admin-sourcing",
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-visual-regression-test-app",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Super simple app VG testing app with login",
   "scripts": {
     "approve": "backstop approve",

--- a/scripts/build-and-push-docker-image.sh
+++ b/scripts/build-and-push-docker-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=2.0.0
+VERSION=2.1.0
 
 docker build -t digitalmarketplace/backstopjs:${VERSION} .
 docker push digitalmarketplace/backstopjs:${VERSION}


### PR DESCRIPTION
Currently we have hard coded URLs for some of our tests. We should handle this better but for the sake of brevity, this updates them to point at DOS3.

The version has a major and a minor bump on it because it looks like the major version was missed last time a breaking change was made (see changelog.)