### PR TITLE
Remove references to production users from envvars

### DIFF
--- a/backstop_data/engine_scripts/casper/user.js
+++ b/backstop_data/engine_scripts/casper/user.js
@@ -2,20 +2,20 @@ var system = require('system');
 
 module.exports = function (casper, scenario) {
   if (scenario.user === 'supplier') {
-    var email = system.env.DM_PRODUCTION_SUPPLIER_USER_EMAIL;
-    var password = system.env.DM_PRODUCTION_SUPPLIER_USER_PASSWORD;
+    var email = system.env.DM_SUPPLIER_USER_EMAIL;
+    var password = system.env.DM_SUPPLIER_USER_PASSWORD;
   } else if (scenario.user === 'buyer') {
-    var email = system.env.DM_PRODUCTION_BUYER_USER_EMAIL;
-    var password = system.env.DM_PRODUCTION_BUYER_USER_PASSWORD;
+    var email = system.env.DM_BUYER_USER_EMAIL;
+    var password = system.env.DM_BUYER_USER_PASSWORD;
   } else if (scenario.user === 'admin-support') {
-    var email = system.env.DM_PRODUCTION_ADMIN_USER_EMAIL;
-    var password = system.env.DM_PRODUCTION_ADMIN_USER_PASSWORD;
+    var email = system.env.DM_ADMIN_USER_EMAIL;
+    var password = system.env.DM_ADMIN_USER_PASSWORD;
   } else if (scenario.user === 'admin-category') {
-    var email = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_EMAIL;
-    var password = system.env.DM_PRODUCTION_ADMIN_CCS_CATEGORY_USER_PASSWORD;
+    var email = system.env.DM_ADMIN_CCS_CATEGORY_USER_EMAIL;
+    var password = system.env.DM_ADMIN_CCS_CATEGORY_USER_PASSWORD;
   } else if (scenario.user === 'admin-sourcing') {
-    var email = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_EMAIL;
-    var password = system.env.DM_PRODUCTION_ADMIN_CCS_SOURCING_USER_PASSWORD;
+    var email = system.env.DM_ADMIN_CCS_SOURCING_USER_EMAIL;
+    var password = system.env.DM_ADMIN_CCS_SOURCING_USER_PASSWORD;
   } else {
     casper.echo('No user required for this scenario.', 'DEBUG');
   }


### PR DESCRIPTION
We don't want to give the impression that these credentials are actually for produciton users.