### PR TITLE
Fix form selector

### DIFF
--- a/backstop_data/engine_scripts/casper/submitFormHelper.js
+++ b/backstop_data/engine_scripts/casper/submitFormHelper.js
@@ -2,6 +2,6 @@
 module.exports = function(casper, scenario) {
   //just submit the empty form
   casper.thenEvaluate(function() {
-    document.querySelector('form:nth-child(2)').submit(); //logout now first form on page.
+    document.querySelector('main form').submit(); // ignore forms in header and footer
   });
 };

--- a/config.js
+++ b/config.js
@@ -130,6 +130,11 @@ module.exports = {
       "url": domain + "/suppliers/mailing-list",
     },
     {
+      "label": environment + ": Supplier - Sign up for framework alerts - Validation",
+      "url": domain + "/suppliers/mailing-list",
+      "submitForm": true
+    },
+    {
       "label": environment + ": Supplier - DUNS number",
       "url": domain + "/suppliers/create/duns-number",
     },


### PR DESCRIPTION
In some pages (for instance `/suppliers/mailing-list`) the main form is the third child instead of the second.

This commit changes the selector so it gets the first child in a main tag, which should better exclude login/logout and feedback forms, which are outside this section.

This should fix the visual regression test bug discovered in https://trello.com/c/8HaNvlZ3/346-feedback-form-can-be-submitted-without-any-data, so this PR also restores the test that failed.