### PR TITLE
766-visual-regression-not-regressing

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,6 +24,7 @@ module.exports = {
       "height": 768
     }
   ],
+  "misMatchThreshold": 0,
   "onBeforeScript": "onBefore.js",
   "onReadyScript": "onReady.js",
   "scenarios": [


### PR DESCRIPTION
* Adjust misMatchThreshold value down from 0.1 to 0

https://github.com/garris/BackstopJS#changing-test-sensitivity
https://trello.com/c/7nUNBc6c/766-visual-regression-not-regressing