### PR TITLE
Fix flakiness with hovering

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/clickAndHoverHelper.js
+++ b/backstop_data/engine_scripts/puppeteer/clickAndHoverHelper.js
@@ -17,6 +17,11 @@ module.exports = async (page, scenario) => {
     }
   }
 
+  if (!hoverSelector) {
+    // make sure we're not hovering over anything that could change state
+    await page.mouse.move(0, 0);
+  }
+
   if (postInteractionWait) {
     await page.waitFor(postInteractionWait);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-visual-regression-test-app",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dm-visual-regression-test-app",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Visual regression testing app with login for the Digital Marketplace",
   "scripts": {
     "approve": "backstop approve",


### PR DESCRIPTION
Our visual regression tests are occasionaly seeing differences because
the mouse happens to be hovering over a link and causing it to change
state; this PR should fix that by moving the mouse to the top-left
corner every time.