### PR TITLE
Fix login script

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/login.js
+++ b/backstop_data/engine_scripts/puppeteer/login.js
@@ -23,7 +23,7 @@ module.exports = async (page, scenario) => {
 
   await Promise.all([
     page.waitForNavigation(),
-    page.click('.button-save'), //should redirect you to desired page
+    page.click('.govuk-button, .button-save'), //should redirect you to desired page
   ]);
 
   return;


### PR DESCRIPTION
Ticket: https://trello.com/c/hRR3O2AX/61-fix-visual-regression-scripts-to-work-with-buttons-from-digital-marketplace-frontend-toolkit-and-govuk-frontend

As part of migrating our frontends to use GOV.UK Design System components, we replaced the buttons in our user frontend (see alphagov/digitalmarketplace-user-frontend#167).

This also had the effect of breaking our visual regression tests, because our script to login to the frontend was looking for the old button class.

This PR changes the script to work with both old and new style buttons, so it should work against preview and staging.