### PR TITLE
Add error pages

### DIFF
--- a/config.js
+++ b/config.js
@@ -193,6 +193,11 @@ module.exports = {
     },
 
     {
+      "label": environment + ": Admin - 403",
+      "url": domain + "/admin/admin-users",
+      "user": "admin-support",
+    },
+    {
       "label": environment + ": Admin - 404",
       "url": domain + "/admin/404",
     },

--- a/config.js
+++ b/config.js
@@ -190,7 +190,32 @@ module.exports = {
       "label": environment + ": Admin (Category) - Account - dashboard",
       "url": domain + "/admin",
       "user": "admin-category",
-    }
+    },
+
+    {
+      "label": environment + ": Admin - 404",
+      "url": domain + "/admin/404",
+    },
+    {
+      "label": environment + ": Buyer - 404",
+      "url": domain + "/404",
+    },
+    {
+      "label": environment + ": Briefs - 404",
+      "url": domain + "/buyers/404",
+    },
+    {
+      "label": environment + ": Brief responses - 404",
+      "url": domain + "/suppliers/opportunities/404",
+    },
+    {
+      "label": environment + ": Supplier - 404",
+      "url": domain + "/suppliers/404",
+    },
+    {
+      "label": environment + ": User - 404",
+      "url": domain + "/user/404",
+    },
   ],
   "paths": {
     "bitmaps_reference": "backstop_data/bitmaps_reference",


### PR DESCRIPTION
We've had an issue where the styling on the error pages for some of apps has been altered as part of the frontend migration; we want to catch such issues in future, so this PR adds the 404 page for each app to the visual regression tests.

I can't off the top of my head think of any easy way to add the other error pages, but as the error page templates are all fairly similar this should catch most issues.