### PR TITLE
Add more tests for admin dashboard with more user roles

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/user.js
+++ b/backstop_data/engine_scripts/puppeteer/user.js
@@ -16,6 +16,15 @@ module.exports = function (scenario) {
   } else if (scenario.user === 'admin-sourcing') {
     var email = process.env.DM_ADMIN_CCS_SOURCING_USER_EMAIL;
     var password = process.env.DM_ADMIN_CCS_SOURCING_USER_PASSWORD;
+  } else if (scenario.user === 'admin-data-controller') {
+    var email = process.env.DM_ADMIN_CCS_DATA_CONTROLLER_USER_EMAIL;
+    var password = process.env.DM_ADMIN_CCS_DATA_CONTROLLER_USER_PASSWORD;
+  } else if (scenario.user === 'admin-framework-manager') {
+    var email = process.env.DM_ADMIN_FRAMEWORK_MANAGER_USER_EMAIL;
+    var password = process.env.DM_ADMIN_FRAMEWORK_MANAGER_USER_PASSWORD;
+  } else if (scenario.user === 'admin-manager') {
+    var email = process.env.DM_ADMIN_MANAGER_USER_EMAIL;
+    var password = process.env.DM_ADMIN_MANAGER_USER_PASSWORD;
   } else {
     console.debug('No user required for this scenario.');
   }

--- a/config.js
+++ b/config.js
@@ -165,10 +165,21 @@ module.exports = {
 
 
     {
+      "label": environment + ": Admin (Category) - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-category",
+    },
+    {
+      "label": environment + ": Admin (Sourcing) - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-sourcing",
+    },
+    {
       "label": environment + ": Admin (Support) - Account - dashboard",
       "url": domain + "/admin",
       "user": "admin-support",
     },
+
     {
       "label": environment + ": Admin (Support) - Account - Add buyer domain",
       "url": domain + "/admin/buyers/add-buyer-domains",
@@ -184,12 +195,6 @@ module.exports = {
       "label": environment + ": Admin (Sourcing) - Account - On-Hold DOS2 agreements",
       "url": domain + "/admin/agreements/digital-outcomes-and-specialists-3?status=on-hold",
       "user": "admin-sourcing",
-    },
-
-    {
-      "label": environment + ": Admin (Category) - Account - dashboard",
-      "url": domain + "/admin",
-      "user": "admin-category",
     },
 
     {

--- a/config.js
+++ b/config.js
@@ -175,9 +175,24 @@ module.exports = {
       "user": "admin-sourcing",
     },
     {
+      "label": environment + ": Admin (Data controller) - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-data-controller",
+    },
+    {
       "label": environment + ": Admin (Support) - Account - dashboard",
       "url": domain + "/admin",
       "user": "admin-support",
+    },
+    {
+      "label": environment + ": Admin (Framework manager) - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-framework-manager",
+    },
+    {
+      "label": environment + ": Admin (Manager) - Account - dashboard",
+      "url": domain + "/admin",
+      "user": "admin-manager",
     },
 
     {


### PR DESCRIPTION
We want more confidence when making changes to the admin frontend such as https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/591.

This PR adds more admin user roles to the visual regression tests, and more tests of the admin dashboard.