### PR TITLE
Add a scenario for the buyer invalid domain error page

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/clickAndHoverHelper.js
+++ b/backstop_data/engine_scripts/puppeteer/clickAndHoverHelper.js
@@ -1,7 +1,16 @@
 module.exports = async (page, scenario) => {
-  var hoverSelector = scenario.hoverSelectors || scenario.hoverSelector;
-  var clickSelector = scenario.clickSelectors || scenario.clickSelector;
-  var postInteractionWait = scenario.postInteractionWait; // selector [str] | ms [int]
+  const hoverSelector = scenario.hoverSelectors || scenario.hoverSelector;
+  const clickSelector = scenario.clickSelectors || scenario.clickSelector;
+  const keyPressSelector = scenario.keyPressSelectors || scenario.keyPressSelector;
+  const scrollToSelector = scenario.scrollToSelector;
+  const postInteractionWait = scenario.postInteractionWait; // selector [str] | ms [int]
+
+  if (keyPressSelector) {
+    for (const keyPressSelectorItem of [].concat(keyPressSelector)) {
+      await page.waitFor(keyPressSelectorItem.selector);
+      await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
+    }
+  }
 
   if (hoverSelector) {
     for (const hoverSelectorIndex of [].concat(hoverSelector)) {
@@ -17,12 +26,14 @@ module.exports = async (page, scenario) => {
     }
   }
 
-  if (!hoverSelector) {
-    // make sure we're not hovering over anything that could change state
-    await page.mouse.move(0, 0);
-  }
-
   if (postInteractionWait) {
     await page.waitFor(postInteractionWait);
+  }
+
+  if (scrollToSelector) {
+    await page.waitFor(scrollToSelector);
+    await page.evaluate(scrollToSelector => {
+      document.querySelector(scrollToSelector).scrollIntoView();
+    }, scrollToSelector);
   }
 };

--- a/config.js
+++ b/config.js
@@ -106,6 +106,17 @@ module.exports = {
 
 
     {
+      "label": environment + ": Buyer - Invalid domain error page",
+      "url": domain + "/buyers/create",
+      "keyPressSelectors": [
+        {
+          "selector": "#input-email_address",
+          "keyPress": "example@example.com",
+        },
+      ],
+      "clickSelector": ".govuk-button",
+    },
+    {
       "label": environment + ": Buyer - Account - Dashboard",
       "url": domain + "/buyers",
       "user": "buyer",


### PR DESCRIPTION
We found an issue with the buyer create account error page (see alphagov/digitalmarketplace-briefs-frontend#249), so we're adding it to the visual regression tests.

We can do this because the engine scripts for BackstopJS now supports entering text into forms!