### PR TITLE
Add an example DOS opportunity

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,6 +61,10 @@ module.exports = {
       "label": environment + ": DOS - Find a user research studio",
       "url": domain + "/buyers/frameworks/digital-outcomes-and-specialists-4/requirements/user-research-studios"
     },
+    {
+      "label": environment + ": DOS - Opportunity",
+      "url": domain + "/digital-outcomes-and-specialists/opportunities/10116"
+    },
 
 
     {


### PR DESCRIPTION
We want to catch any visual regressions to our service/opportunity description pages. This commit adds an example of these pages to the visual regression suite.

The page was chosen at the beginning of the frontend migration mission based on being the most recently awarded opportunity; see https://trello.com/c/Cf71av8D/ for details.