### PR TITLE
Change mismatch test to allow images of different dimensions

### DIFF
--- a/config.js
+++ b/config.js
@@ -25,6 +25,7 @@ module.exports = {
     }
   ],
   "misMatchThreshold": 0,
+  "requireSameDimensions": false,
   "onBeforeScript": "onBefore.js",
   "onReadyScript": "onReady.js",
   "scenarios": [


### PR DESCRIPTION
Ticket: https://trello.com/c/xHWm8kLO/1412-visual-regression-test-flakiness

We've been having issues where our visual regression tests have been failing with images that are similar but have slightly different heights (mainly with mobile and tablet viewports).

This PR changes our configuration to allow images to have different dimensions. This should hopefully fix most if not all of the flakiness.