### PR TITLE
Fix login script

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/login.js
+++ b/backstop_data/engine_scripts/puppeteer/login.js
@@ -23,7 +23,7 @@ module.exports = async (page, scenario) => {
 
   await Promise.all([
     page.waitForNavigation(),
-    page.click('.govuk-button'), //should redirect you to desired page
+    page.click('main .govuk-button'), //should redirect you to desired page
   ]);
 
   return;

--- a/backstop_data/engine_scripts/puppeteer/login.js
+++ b/backstop_data/engine_scripts/puppeteer/login.js
@@ -23,7 +23,7 @@ module.exports = async (page, scenario) => {
 
   await Promise.all([
     page.waitForNavigation(),
-    page.click('.govuk-button, .button-save'), //should redirect you to desired page
+    page.click('.govuk-button'), //should redirect you to desired page
   ]);
 
   return;


### PR DESCRIPTION
We have had an issue where our visual regression tests have been clicking
on the coookie banner accept cookies button instead of the login button, as
both buttons use the same class.

In the long term we should consider adding an id to the login button to 
make it easier to select (or an id to the cookie banner buttons to make it
easier to NOT select them). For now ensuring that the button is inside the
main wrapper is sufficient to make the tests do what we want.