### PR TITLE
Allow two tests to run in parallel

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,7 +30,7 @@ module.exports = {
       "height": 768
     }
   ],
-  "asyncCaptureLimit": 1,
+  "asyncCaptureLimit": 2,
   "misMatchThreshold": 0,
   "requireSameDimensions": false,
   "onBeforeScript": "onBefore.js",


### PR DESCRIPTION
https://trello.com/c/Lj7EZIoV/2208-upgrade-backstop-in-digitalmarketplace-visual-regression

We need to limit the number of tests that can run in parallel. Something (I don't know what?) messes up font loading otherwise. The problem is that the tests are nearly twice as slow with no parallelism as they were with the default (10). This will waste our time during deploys.

See whether we can get the best of both worlds by allowing a small amount of parallelism. Locally, this seems stable to me, so I want to see how it performs on Jenkins. This is probably near the limit, though - I started to get errors at 4.